### PR TITLE
Fix: Resolve duplicate function definition in course page

### DIFF
--- a/course.html
+++ b/course.html
@@ -139,17 +139,17 @@
             courseId = urlParams.get('course');
             
             if (courseId) {
-                loadCourseDetails(courseId);
+                loadCourseDetailsFromApp(courseId);
             } else {
                 // Redirect to home if no course ID provided
                 window.location.href = 'index.html';
             }
         });
         
-        // Load course details from JSON (updated to handle nested topics structure)
-        function loadCourseDetails(courseId) {
+        // Load course details using the function from app.js
+        function loadCourseDetailsFromApp(courseId) {
             // Use the updated loadCourseDetails function from app.js
-            loadCourseDetails(courseId)
+            window.loadCourseDetails(courseId)
                 .then(courseData => {
                     currentCourseData = courseData;
                     displayCourseDetails(courseData);


### PR DESCRIPTION
### Problem:
The [course.html](file:///C:/Users/dyhar/Desktop/WOCS/History-of-all-flight-crash/course.html) file contained a duplicate definition of the [loadCourseDetails](file:///C:/Users/dyhar/Desktop/WOCS/History-of-all-flight-crash/assets/js/app.js#L226-L251) function that was already defined in [app.js](file:///C:/Users/dyhar/Desktop/WOCS/History-of-all-flight-crash/assets/js/app.js). This duplication could lead to unpredictable behavior due to function overriding, maintenance difficulties, and potential bugs if the implementations diverged.
### • Solution:
Renamed the duplicate function in [course.html](file:///C:/Users/dyhar/Desktop/WOCS/History-of-all-flight-crash/course.html) to [loadCourseDetailsFromApp](file:///C:/Users/dyhar/Desktop/WOCS/History-of-all-flight-crash/course.html#L99-L134) to avoid naming conflicts

- Updated the function to properly call the original [loadCourseDetails](file:///C:/Users/dyhar/Desktop/WOCS/History-of-all-flight-crash/assets/js/app.js#L226-L251) function from [app.js](file:///C:/Users/dyhar/Desktop/WOCS/History-of-all-flight-crash/assets/js/app.js) using window.loadCourseDetails(courseId)
- Updated the function call in the DOMContentLoaded event to use the new function name

### • How it fixes the issue:
This change eliminates the function naming conflict by ensuring there is only one definition of [loadCourseDetails]### (file:///C:/Users/dyhar/Desktop/WOCS/History-of-all-flight-crash/assets/js/app.js#L226-L251) in the global scope (from [app.js](file:///C:/Users/dyhar/Desktop/WOCS/History-of-all-flight-crash/assets/js/app.js)), while still allowing [course.html](file:///C:/Users/dyhar/Desktop/WOCS/History-of-all-flight-crash/course.html) to have its own wrapper function with a different name that properly calls the original function. This makes the code more maintainable and prevents unexpected behavior.